### PR TITLE
Fix broken "how many batches per entity?" query

### DIFF
--- a/examples/explore_db.clj
+++ b/examples/explore_db.clj
@@ -32,7 +32,7 @@
 
 (defn batch-entity
   [batch-id]
-  (str/replace batch-id #"-.*" ""))
+  (str/replace batch-id #"-[^-]*$" ""))
 
 (->> (client/q conn {:query '[:find ?id
                               :where [_ :mbrainz.initial-import/batch-id ?id]]


### PR DESCRIPTION
batch-entity function was returning "releases" for input "releases-artists-1", when it should have been returning "releases-artists". Change the regex so that only the final hyphen and subsequent characters are removed.